### PR TITLE
feat: return raw manifest

### DIFF
--- a/registry/router.go
+++ b/registry/router.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +9,7 @@ import (
 
 	"github.com/docker/docker/api/server/router"
 	"github.com/docker/docker/errdefs"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"golang.org/x/xerrors"
 )
 
@@ -63,16 +62,15 @@ func (s *registryRouter) manifestHandler(ctx context.Context, w http.ResponseWri
 		return errdefs.NotFound(xerrors.Errorf("unknown image: %s", imageName))
 	}
 
-	m, err := img.Manifest()
+	media, err := img.MediaType()
 	if err != nil {
 		return errdefs.Unavailable(err)
 	}
 
-	w.Header().Set("Content-Type", string(m.MediaType))
+	w.Header().Set("Content-Type", string(media))
 	w.WriteHeader(http.StatusOK)
 
-	// Use json.Marshal instead of json.NewEncoder to avoid writing a newline
-	b, err := json.Marshal(m)
+	b, err := img.RawManifest()
 	if err != nil {
 		return errdefs.Unavailable(err)
 	}


### PR DESCRIPTION
Return the raw manifest to avoid formatting issues during json marshaling. This is necessary to preserve the original manifest digest, otherwise it may result in mismatches with errors such as:

```
getting image: manifest digest: "sha256:16849e7bf3d46ea5065178bfd35d4ce828d184392212d2690733206eacf20d0d" does not match requested digest: "sha256:1c4eef651f65e2f7daee7ee785882ac164b02b78fb74503052a26dc061c90474" for "127.0.0.1:62864/alpine@sha256:1c4eef651f65e2f7daee7ee785882ac164b02b78fb74503052a26dc061c90474"
```
