### PR TITLE
chore(deps): Upgrade Docker to v28.2.2

### DIFF
--- a/engine/image/router.go
+++ b/engine/image/router.go
@@ -12,9 +12,9 @@ import (
 	"github.com/aquasecurity/testdocker/tarfile"
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/router"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	itype "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/storage"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
@@ -154,7 +154,7 @@ func (s *imageRouter) getImagesByName(_ context.Context, w http.ResponseWriter, 
 			Shell:       config.Config.Shell,
 		},
 	}
-	inspect := types.ImageInspect{
+	inspect := itype.InspectResponse{
 		ID:              manifest.Config.Digest.String(),
 		RepoTags:        manifests[0].RepoTags,
 		RepoDigests:     nil, // not supported
@@ -170,8 +170,8 @@ func (s *imageRouter) getImagesByName(_ context.Context, w http.ResponseWriter, 
 		OsVersion:       config.OSVersion,
 		Size:            0,                       // not supported
 		VirtualSize:     0,                       // not supported
-		GraphDriver:     types.GraphDriverData{}, // not supported
-		RootFS: types.RootFS{
+		GraphDriver:     storage.DriverData{}, // not supported
+		RootFS: itype.RootFS{
 			Type:   config.RootFS.Type,
 			Layers: diffIDs,
 		},

--- a/engine/image/router.go
+++ b/engine/image/router.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/server/router"
 	"github.com/docker/docker/api/types/container"
-	itype "github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/storage"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -154,7 +154,7 @@ func (s *imageRouter) getImagesByName(_ context.Context, w http.ResponseWriter, 
 			Shell:       config.Config.Shell,
 		},
 	}
-	inspect := itype.InspectResponse{
+	inspect := image.InspectResponse{
 		ID:              manifest.Config.Digest.String(),
 		RepoTags:        manifests[0].RepoTags,
 		RepoDigests:     nil, // not supported
@@ -171,11 +171,11 @@ func (s *imageRouter) getImagesByName(_ context.Context, w http.ResponseWriter, 
 		Size:            0,                       // not supported
 		VirtualSize:     0,                       // not supported
 		GraphDriver:     storage.DriverData{}, // not supported
-		RootFS: itype.RootFS{
+		RootFS: image.RootFS{
 			Type:   config.RootFS.Type,
 			Layers: diffIDs,
 		},
-		Metadata: itype.Metadata{},
+		Metadata: image.Metadata{},
 	}
 
 	if err = json.NewEncoder(w).Encode(inspect); err != nil {
@@ -271,7 +271,7 @@ func (s *imageRouter) getImageHistory(ctx context.Context, w http.ResponseWriter
 		return errdefs.Unavailable(err)
 	}
 
-	var inspectHistory []itype.HistoryResponseItem
+	var inspectHistory []image.HistoryResponseItem
 	var layerSize int64
 	layerIndex := 0
 	for _, configHistory := range config.History {
@@ -281,7 +281,7 @@ func (s *imageRouter) getImageHistory(ctx context.Context, w http.ResponseWriter
 			layerSize = allLayerSizes[layerIndex]
 			layerIndex++
 		}
-		inspectHistory = append(inspectHistory, itype.HistoryResponseItem{
+		inspectHistory = append(inspectHistory, image.HistoryResponseItem{
 			Comment:   configHistory.Comment,
 			Created:   configHistory.Created.Unix(),
 			CreatedBy: configHistory.CreatedBy,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/testdocker
 go 1.21
 
 require (
-	github.com/docker/docker v26.1.3+incompatible
+	github.com/docker/docker v28.2.2+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/go-containerregistry v0.19.1
@@ -15,7 +15,7 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/containerd/containerd v1.6.26 // indirect
+	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -27,6 +27,8 @@ require (
 	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/sys/atomicwriter v0.1.0 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -37,8 +39,10 @@ require (
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/v3 v3.5.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@ go 1.21
 
 require (
 	github.com/docker/docker v28.2.2+incompatible
-	github.com/docker/go-connections v0.4.0
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/go-containerregistry v0.19.1
 	github.com/gorilla/mux v1.7.4
+	github.com/moby/docker-image-spec v1.3.1
+	github.com/opencontainers/image-spec v1.1.0-rc3
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 	google.golang.org/grpc v1.58.3
@@ -21,18 +22,17 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0-rc3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/containerd/containerd v1.6.26 h1:VVfrE6ZpyisvB1fzoY8Vkiq4sy+i5oF4uk7zu03RaHs=
-github.com/containerd/containerd v1.6.26/go.mod h1:I4TRdsdoo5MlKob5khDJS2EPT1l1oMNaE2MBm6FrwxM=
+github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
+github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
@@ -20,8 +20,8 @@ github.com/docker/cli v24.0.0+incompatible h1:0+1VshNwBQzQAx9lOl+OYCTCEAD8fKs/qe
 github.com/docker/cli v24.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.3+incompatible h1:lLCzRbrVZrljpVNobJu1J2FHk8V0s4BawoZippkc+xo=
-github.com/docker/docker v26.1.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.2.2+incompatible h1:CjwRSksz8Yo4+RmQ339Dp/D2tGO5JxwYeqtMOEe0LDw=
+github.com/docker/docker v28.2.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -54,6 +54,10 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
+github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
+github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
+github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
+github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=


### PR DESCRIPTION
## Summary
- Upgrade Docker dependency from v26.1.3 to v28.2.2+incompatible
- Fix compilation error in engine/image/router.go by migrating to OCI-compliant configuration
- Maintain backward compatibility while adopting modern Docker image specifications

## Changes
- Update go.mod to use Docker v28.2.2+incompatible
- Replace container.Config with DockerOCIImageConfig in ImageInspect.Config field
- Preserve healthcheck, OnBuild, and Shell configurations in Docker extensions  
- Simplify code by removing unused variables and imports
- Keep deprecated ContainerConfig field for backward compatibility